### PR TITLE
sanitize dependency on hyper-cmd-lib-keys

### DIFF
--- a/keygen.js
+++ b/keygen.js
@@ -2,7 +2,7 @@
 const HyperDHT = require('hyperdht')
 const fs = require('fs')
 const argv = require('minimist')(process.argv.slice(2))
-const libKeys = require('@hyper-cmd/lib-keys')
+const libKeys = require('hyper-cmd-lib-keys')
 
 function storeKeyPair (k) {
   return JSON.stringify({

--- a/package.json
+++ b/package.json
@@ -4,11 +4,10 @@
   "description": "HyperCmd Utils",
   "main": "index.js",
   "dependencies": {
-    "@hyper-cmd/lib-keys": "https://github.com/holepunchto/hyper-cmd-lib-keys",
+    "hyper-cmd-lib-keys": "^0.1.1",
     "hyperdht": "^6.5.2",
     "minimist": "^1.2.5"
   },
-  "devDependencies": {},
   "bin": {
     "hyper-cmd-util-keygen": "./keygen.js"
   },


### PR DESCRIPTION
remove git URL that doesn't contain tag for better reproducibility
